### PR TITLE
If the Latest Version of an Object Is the Same Version as What Will Be Restored Skip It.

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ usage: s3-pit-restore [-h] -b BUCKET [-B DEST_BUCKET] [-d DEST]
                       [-P DEST_PREFIX] [-p PREFIX] [-t TIMESTAMP]
                       [-f FROM_TIMESTAMP] [-e] [-v] [--dry-run] [--debug]
                       [--test] [--max-workers MAX_WORKERS]
+					  [--avoid-duplicates]
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -111,6 +112,7 @@ optional arguments:
   --test                s3 pit restore testing
   --max-workers MAX_WORKERS
                         max number of concurrent download requests
+  --avoid-duplicates	tries to avoid sopying files that are already at the latest version
 ```
 
 ## Docker Usage

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ optional arguments:
   --test                s3 pit restore testing
   --max-workers MAX_WORKERS
                         max number of concurrent download requests
-  --avoid-duplicates    tries to avoid sopying files that are already at the latest version
+  --avoid-duplicates    tries to avoid copying files that are already at the latest version
 ```
 
 ## Docker Usage

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ usage: s3-pit-restore [-h] -b BUCKET [-B DEST_BUCKET] [-d DEST]
                       [-P DEST_PREFIX] [-p PREFIX] [-t TIMESTAMP]
                       [-f FROM_TIMESTAMP] [-e] [-v] [--dry-run] [--debug]
                       [--test] [--max-workers MAX_WORKERS]
-					  [--avoid-duplicates]
+                      [--avoid-duplicates]
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -112,7 +112,7 @@ optional arguments:
   --test                s3 pit restore testing
   --max-workers MAX_WORKERS
                         max number of concurrent download requests
-  --avoid-duplicates	tries to avoid sopying files that are already at the latest version
+  --avoid-duplicates    tries to avoid sopying files that are already at the latest version
 ```
 
 ## Docker Usage

--- a/s3-pit-restore
+++ b/s3-pit-restore
@@ -236,7 +236,7 @@ def handled_by_standard(obj):
     return True
 
 def handled_by_copy(obj):
-    if not needs_copy(obj):
+    if args.avoid_duplicates and not needs_copy(obj):
         return True
     if args.dry_run:        
         print_obj(obj)
@@ -411,6 +411,7 @@ if __name__=='__main__':
     parser.add_argument('--debug', help='enable debug output', action='store_true')
     parser.add_argument('--test', help='s3 pit restore testing', action='store_true')
     parser.add_argument('--max-workers', help='max number of concurrent download requests', default=10, type=int)
+    parser.add_argument('--avoid-duplicates', help='avoids copying files if the latest version is the version that matches timestamp requested', action='store_true')
     args = parser.parse_args()
 
     if args.dest_bucket is None and not args.dest:

--- a/s3-pit-restore
+++ b/s3-pit-restore
@@ -32,6 +32,7 @@ import os, sys, time, signal, argparse, boto3, botocore, \
 from datetime import datetime, timezone
 from dateutil.parser import parse
 from s3transfer.manager import TransferConfig
+from botocore.exceptions import ClientError
 
 args = None
 executor = None
@@ -184,11 +185,10 @@ def signal_handler(signal, frame):
     print("Gracefully exiting ...")
 
 def print_obj(obj, optional_message=""):
-    print("")
-    #if args.verbose:
-        #print('"%s" %s %s %s %s %s' % (obj["LastModified"], obj["VersionId"], obj["Size"], obj["StorageClass"], obj["Key"], optional_message))
-    #else:
-        #print(obj["Key"])
+    if args.verbose:
+        print('"%s" %s %s %s %s %s' % (obj["LastModified"], obj["VersionId"], obj["Size"], obj["StorageClass"], obj["Key"], optional_message))
+    else:
+        print(obj["Key"])
 
 def handled_by_glacier(obj):
     if obj["StorageClass"] == "GLACIER" and not args.enable_glacier:
@@ -230,22 +230,35 @@ def handled_by_standard(obj):
             global futures
             futures[future] = obj
         else:
-            print("Handling via standard")
             print_obj(obj)
     except RuntimeError:
         return False
     return True
 
 def handled_by_copy(obj):
-    if args.dry_run:
-        #print("handling via copy")
-        is_correct_version(obj)
+    if not needs_copy(obj):
+        return True
+    if args.dry_run:        
         print_obj(obj)
         return True
     future = executor.submit(s3_copy_object, obj)
     global futures
     futures[future] = obj
     return True
+
+def needs_copy(obj):
+    try:
+        destination_object_data = client.head_object(Bucket=args.dest_bucket, Key=obj["Key"])
+    except ClientError as error:
+        if error.response['ResponseMetadata']['HTTPStatusCode'] == 404:
+            return True
+        else:
+            raise error
+    # Won't work for files uploaded with different multipart chunk sizes
+    if args.bucket != args.dest_bucket:
+        return obj["ETag"] != destination_object_data["ETag"]
+    else:
+        return obj["VersionId"] != destination_object_data["VersionId"]
 
 def download_file(obj):
     transfer.download_file(args.bucket, obj["Key"], obj["Key"], extra_args={"VersionId": obj["VersionId"]})
@@ -257,14 +270,6 @@ def get_key(obj):
         return  obj["Key"]
     return os.path.join(args.dest_prefix, obj["Key"])
 
-def is_correct_version(obj):
-    print(obj["Key"])
-    print('What I was handed %s' % (obj["VersionId"]))
-    source_etag = obj["VersionId"]
-    response = client.head_object(Bucket=args.dest_bucket, Key=obj["Key"])
-    print('What is currently there : %s' % (response["VersionId"]))
-    destination_etag = response["VersionId"]
-    print("Has changed? %s" % (source_etag != destination_etag))
 
 def s3_copy_object(obj):
     copy_source= {

--- a/s3-pit-restore
+++ b/s3-pit-restore
@@ -184,10 +184,11 @@ def signal_handler(signal, frame):
     print("Gracefully exiting ...")
 
 def print_obj(obj, optional_message=""):
-    if args.verbose:
-        print('"%s" %s %s %s %s %s' % (obj["LastModified"], obj["VersionId"], obj["Size"], obj["StorageClass"], obj["Key"], optional_message))
-    else:
-        print(obj["Key"])
+    print("")
+    #if args.verbose:
+        #print('"%s" %s %s %s %s %s' % (obj["LastModified"], obj["VersionId"], obj["Size"], obj["StorageClass"], obj["Key"], optional_message))
+    #else:
+        #print(obj["Key"])
 
 def handled_by_glacier(obj):
     if obj["StorageClass"] == "GLACIER" and not args.enable_glacier:
@@ -229,6 +230,7 @@ def handled_by_standard(obj):
             global futures
             futures[future] = obj
         else:
+            print("Handling via standard")
             print_obj(obj)
     except RuntimeError:
         return False
@@ -236,6 +238,8 @@ def handled_by_standard(obj):
 
 def handled_by_copy(obj):
     if args.dry_run:
+        #print("handling via copy")
+        is_correct_version(obj)
         print_obj(obj)
         return True
     future = executor.submit(s3_copy_object, obj)
@@ -252,6 +256,15 @@ def get_key(obj):
     if not args.dest_prefix:
         return  obj["Key"]
     return os.path.join(args.dest_prefix, obj["Key"])
+
+def is_correct_version(obj):
+    print(obj["Key"])
+    print('What I was handed %s' % (obj["VersionId"]))
+    source_etag = obj["VersionId"]
+    response = client.head_object(Bucket=args.dest_bucket, Key=obj["Key"])
+    print('What is currently there : %s' % (response["VersionId"]))
+    destination_etag = response["VersionId"]
+    print("Has changed? %s" % (source_etag != destination_etag))
 
 def s3_copy_object(obj):
     copy_source= {

--- a/s3-pit-restore
+++ b/s3-pit-restore
@@ -270,7 +270,6 @@ def get_key(obj):
         return  obj["Key"]
     return os.path.join(args.dest_prefix, obj["Key"])
 
-
 def s3_copy_object(obj):
     copy_source= {
         'Bucket': args.bucket,


### PR DESCRIPTION
Makes an API call to determine if the latest object is the same one as the one that needs to be restored, if so it will skip the copy. This also introduces a new CLI flag --avoid-duplicates that this new funcationality lives behind, if the flag isn't set the old behavior is preserved.

Sorry for the inudation of PRs. Found this tool and it did 97% of what I needed, wanted to help bring it to 100%. I'm sure I'll have to fix some merge conflicts as they are merged in, happy to do that as we go but wanted to make a PR for each individual solution so we can discuss each in isolation.