### PR TITLE
Ability to specify server-side encryption headers when copying to S3

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ usage: s3-pit-restore [-h] -b BUCKET [-B DEST_BUCKET] [-d DEST]
                       [-P DEST_PREFIX] [-p PREFIX] [-t TIMESTAMP]
                       [-f FROM_TIMESTAMP] [-e] [-v] [--dry-run] [--debug]
                       [--test] [--max-workers MAX_WORKERS]
+                      [--sse {AES256,aws:kms}]
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -111,6 +112,8 @@ optional arguments:
   --test                s3 pit restore testing
   --max-workers MAX_WORKERS
                         max number of concurrent download requests
+  --sse ALGORITHM
+                        specify what SSE algorithm you would like to use for the copy
 ```
 
 ## Docker Usage

--- a/s3-pit-restore
+++ b/s3-pit-restore
@@ -259,7 +259,13 @@ def s3_copy_object(obj):
         'Key': obj["Key"],
         'VersionId': obj["VersionId"]
     }
-    client.copy(Bucket=args.dest_bucket, CopySource=copy_source, Key=get_key(obj))
+
+    extra_args = { }
+
+    if args.sse is not None:
+        extra_args['ServerSideEncryption'] = args.sse
+
+    client.copy(Bucket=args.dest_bucket, CopySource=copy_source, Key=get_key(obj), ExtraArgs=extra_args)
 
 def handled_by_delete(obj):
     if args.dry_run:
@@ -393,6 +399,7 @@ if __name__=='__main__':
     parser.add_argument('--debug', help='enable debug output', action='store_true')
     parser.add_argument('--test', help='s3 pit restore testing', action='store_true')
     parser.add_argument('--max-workers', help='max number of concurrent download requests', default=10, type=int)
+    parser.add_argument('--sse', choices=['AES256', 'aws:kms'], help='Specify server-side encryption')
     args = parser.parse_args()
 
     if args.dest_bucket is None and not args.dest:


### PR DESCRIPTION
Adds the --sse flag. This optional flag allows one of two values: AES256, aws:kms (this particular PR doesn't provide customer managed keys but shouldn't prevent the addition of that in the future). When one of these values is provided, when a copy is made the SSE headers will also be sent. If the flag is not set no SSE headers will be sent and the behavior will be the same as what it was before.