### PR TITLE
build docker image from code

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,16 +4,20 @@ FROM python:3-alpine3.17
 ARG BUILD_DATE
 ARG VCS_REF
 ARG VERSION
-LABEL org.label-schema.build-date=${BUILD_DATE} \
-          org.label-schema.name="s3-pit-restore" \
-          org.label-schema.description="a point in time restore tool for Amazon S3." \
-          org.label-schema.vcs-ref=${VCS_REF} \
-          org.label-schema.vcs-url="https://github.com/angeloc/s3-pit-restore" \
-          org.label-schema.vendor="angeloc" \
-          org.label-schema.version=${VERSION} \
-          org.label-schema.schema-version="v0.9"
+LABEL     org.opencontainers.image.created=${BUILD_DATE} \
+          org.opencontainers.image.url="https://github.com/angeloc/s3-pit-restore" \
+          org.opencontainers.image.version=${VERSION} \
+          org.opencontainers.image.revision=${VCS_REF} \
+          org.opencontainers.image.vendor="angeloc" \
+          org.opencontainers.image.licenses="MIT" \
+          org.opencontainers.image.title="s3-pit-restore" \
+          org.opencontainers.image.description="a point in time restore tool for Amazon S3."
 
-RUN pip3 --no-cache-dir install s3-pit-restore awscli
+RUN pip3 --no-cache-dir install awscli
+
+ADD . /tmp/
+WORKDIR /tmp/
+RUN python3 setup.py install
 
 ENTRYPOINT [ "s3-pit-restore" ]
 CMD [ "-h" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,6 @@ LABEL     org.opencontainers.image.created=${BUILD_DATE} \
           org.opencontainers.image.title="s3-pit-restore" \
           org.opencontainers.image.description="a point in time restore tool for Amazon S3."
 
-RUN pip3 --no-cache-dir install awscli
-
 ADD . /tmp/
 WORKDIR /tmp/
 RUN python3 setup.py install

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3-alpine3.17
 
-# Build-time metadata as defined at http://label-schema.org
+# Build-time metadata as defined at https://github.com/opencontainers/image-spec/blob/main/annotations.md
 ARG BUILD_DATE
 ARG VCS_REF
 ARG VERSION

--- a/README.md
+++ b/README.md
@@ -101,13 +101,10 @@ or clone the repository and launch:
 ## Command line options
 
 ```
-usage: s3-pit-restore [-h] -b BUCKET [-B DEST_BUCKET] [-d DEST]
-                      [-P DEST_PREFIX] [-p PREFIX] [-t TIMESTAMP]
-                      [-f FROM_TIMESTAMP] [-e] [-v] [--dry-run] [--debug]
-                      [--test] [--max-workers MAX_WORKERS]
+usage: s3-pit-restore [-h] -b BUCKET [-B DEST_BUCKET] [-d DEST] [-p PREFIX] [-P DEST_PREFIX] [-t TIMESTAMP] [-f FROM_TIMESTAMP] [-e] [-v] [-u ENDPOINT_URL] [--dry-run] [--debug] [--test] [--max-workers MAX_WORKERS]
                       [--sse {AES256,aws:kms}]
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
   -b BUCKET, --bucket BUCKET
                         s3 bucket to restore from
@@ -124,13 +121,15 @@ optional arguments:
                         starting point in time to restore from
   -e, --enable-glacier  enable recovering from glacier
   -v, --verbose         print verbose informations from s3 objects
+  -u ENDPOINT_URL, --endpoint-url ENDPOINT_URL
+                        use another endpoint URL for s3 service
   --dry-run             execute query without transferring files
   --debug               enable debug output
   --test                s3 pit restore testing
   --max-workers MAX_WORKERS
                         max number of concurrent download requests
-  --sse ALGORITHM
-                        specify what SSE algorithm you would like to use for the copy
+  --sse {AES256,aws:kms}
+                        Specify server-side encryption
 ```
 
 ## Docker Usage
@@ -140,7 +139,7 @@ optional arguments:
 mkdir restore
 
 # restore a point in time copy under the restore dir you just created
-docker run -ti --rm --name=s3-pit-restore -v {$PWD}/restore:/tmp -e AWS_ACCESS_KEY_ID=[AWS_ACCESS_KEY_ID] -e AWS_SECRET_ACCESS_KEY=[AWS_ACCESS_KEY_ID] angelocompagnucci/s3-pit-restore:latest s3-pit-restore -b [Bucket] -p [Prefix] -d /tmp -t "01-25-2018 10:59:50 +2"
+docker run -ti --rm --name=s3-pit-restore -v {$PWD}/restore:/tmp -e AWS_ACCESS_KEY_ID=[AWS_ACCESS_KEY_ID] -e AWS_SECRET_ACCESS_KEY=[AWS_ACCESS_KEY_ID] angelocompagnucci/s3-pit-restore -b [Bucket] -p [Prefix] -d /tmp -t "01-25-2018 10:59:50 +2"
 ```
 
 ## Testing

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+BUILD_DATE="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+VCS_REF="$(git rev-parse --short=7 HEAD)"
+VERSION="$(git rev-parse --abbrev-ref HEAD)"
+docker build --build-arg BUILD_DATE="$BUILD_DATE" --build-arg VCS_REF="$VCS_REF" --build-arg VERSION="$VERSION" -t angelocompagnucci/s3-pit-restore .


### PR DESCRIPTION
Builds the docker image from the code itself, so you can build images for things other than the latest version in PyPI.

Updated labels to OCI format (https://github.com/opencontainers/image-spec/blob/main/annotations.md)

Added shell script to build image.
