### PR TITLE
Fix paging-related bugs by reworking the strategy

### DIFF
--- a/s3-pit-restore
+++ b/s3-pit-restore
@@ -355,10 +355,6 @@ def do_restore():
     dest = args.dest
     last_obj = {}
     last_obj["Key"] = ""
-    # The key that was given for the latest version that was flagged with IsLatest=true.
-    is_latest_key = None
-    # The etag that was given for the latest version that was flagged with IsLatest=true.
-    is_latest_etag = None
 
     if args.debug: boto3.set_stream_logger('botocore')
 
@@ -372,80 +368,95 @@ def do_restore():
         os.chdir(dest)
 
     paginator = client.get_paginator('list_object_versions')
-    obj_needs_be_deleted = {}
     page_iterator = paginator.paginate(Bucket=args.bucket, Prefix=args.prefix)
-    # Delete markers can get desynchronized with the versions markers in the pagination system below.
-    # To avoid this, we will push from page to page the desynchronized markers until they fall on the
-    # page they should (the one with the versioning markers for the same set of files)
-    previous_deletemarkers = []
+
+    # A running aggregate of objects versions and delete markers, by key.
+    aggr_objects_by_key = {}
+
     for page in page_iterator:
-        if not "Versions" in page:
-            print("No versions matching criteria, exiting ...", file=sys.stderr)
-            sys.exit(1)
-        versions = page["Versions"]
-        # Some deletemarkers may come from the previous page: add them now
-        deletemarkers = previous_deletemarkers + page.get("DeleteMarkers", [])
-        # And since they have been added, we remove them from the overflow list
-        previous_deletemarkers = []
-        dmarker = {"Key": "", "IsLatest": False}
-        for obj in versions:
-            if last_obj["Key"] == obj["Key"]:
-                # We've had a newer version or a delete of this key
+        # Add this page's versions and delete markers to the running aggregate.
+        for obj in page.get("Versions", []) + page.get("DeleteMarkers", []):
+            # Add helper attribute to discern versions and delete markers.
+            obj["IsVersion"] = "Size" in obj
+
+            # Append the object to the running aggregate of objects.
+            aggr_objects_by_key.setdefault(obj["Key"], []).append(obj)
+
+        # Sort the aggregated keys.
+        aggregated_keys = sorted(list(aggr_objects_by_key.keys()))
+
+        # Remove the last key in the list if we haven't reached the last page,
+        # since that key name may have more versions or delete markers on
+        # following pages. This leaves us only with keys that we definitively
+        # have all the versions or delete markers for.
+        if page["IsTruncated"] and aggregated_keys:
+            aggregated_keys.pop()
+
+        # Process the list of aggregated objects, now known to be complete as of
+        # the current page. The list may be empty if we've only seen a single
+        # key's versions or delete markers so far (i.e. more might follow).
+        for key in aggregated_keys:
+            # Iterate over all versions and delete markers for this key,
+            # reverse-ordered by LastModified, IsLatest and IsVersion.
+            objects_sorted = sorted(
+                aggr_objects_by_key[key],
+                key=lambda o: (
+                    o["LastModified"],  # newest first
+                    o["IsLatest"],  # latest before non-latest
+                    o["IsVersion"],  # versions before delete markers
+                ),
+                reverse=True,
+            )
+
+            # Keep track of this key's latest version or delete marker.
+            obj_latest = next(o for o in objects_sorted if o["IsLatest"])
+
+            # Only consider objects within the restore window.
+            objects_filtered = list(filter(
+                lambda o: pit_start_date <= o["LastModified"] <= pit_end_date,
+                objects_sorted,
+            ))
+
+            # Special case to restore the non-existence of an object within the
+            # same bucket, if the latest object is a version.
+            if len(objects_filtered) == 0:
+                if args.bucket == args.dest_bucket and obj_latest["IsVersion"]:
+                    handled_by_delete(obj)
                 continue
 
-            if obj["IsLatest"]:
-                is_latest_key = obj["Key"]
-                is_latest_etag = obj["ETag"]
+            # Restore the most recent object for this key.
+            obj = objects_filtered[0]
 
-            version_date = obj["LastModified"]
+            # Handle object version.
+            if obj["IsVersion"]:
+                if handled_by_glacier(obj):
+                    continue
 
-            if version_date > pit_end_date or version_date < pit_start_date:
-                if pit_start_date == datetime.fromtimestamp(0, timezone.utc):
-                    obj_needs_be_deleted[obj["Key"]] = obj
-                continue
+                # Handle all cases where a destination bucket is specified.
+                if args.dest_bucket is not None:
+                    # Copy to other bucket or prefix.
+                    if args.bucket != args.dest_bucket or args.dest_prefix:
+                        handled_by_copy(obj)
+                        continue
 
-            # Dont go farther in the deletemarkers list than the current key, or else we risk consuming desync delete markers of the next page
-            # (both versions and deletemarkers list are sorted in alphabetical order of the key, and then in reverse time order for each key)
-            while deletemarkers and (dmarker["Key"] < obj["Key"] or (dmarker["Key"] == obj["Key"] and dmarker["LastModified"] > pit_end_date)):
-                dmarker = deletemarkers.pop(0)
-                if dmarker['IsLatest']:
-                    # The given object is already deleted and does not have to be deleted again.
-                    obj_needs_be_deleted.pop(dmarker["Key"], None)
-
-            #skip dmarker if it's latest than pit_end_date
-            if dmarker["Key"] == obj["Key"] and dmarker["LastModified"] > obj["LastModified"] and dmarker["LastModified"] <= pit_end_date:
-                # The most recent operation on this key was a delete
-                last_obj = dmarker
-                continue
-
-            # This version needs to be restored..
-            last_obj = obj
-
-            if handled_by_glacier(obj):
-                continue
-
-            if args.dest_bucket is not None:
-                obj_needs_be_deleted.pop(obj["Key"], None)
-
-                # We can skip the restore if the current version is equivalent to the newest version
-                # of the object and if we want to restore it to the same bucket and path.
-                # is_latest_key == obj["Key"] also ensures that the object is not currently deleted,
-                # because a version with IsLatest=true was observed.
-                if is_latest_key != obj["Key"] or \
-                        is_latest_etag != obj["ETag"] or \
-                        args.bucket != args.dest_bucket or \
-                        args.dest_prefix:
+                # Same bucket and prefix, in-place restore.
+                # Restore version if it's not already the latest.
+                if obj_latest["VersionId"] != obj["VersionId"]:
                     handled_by_copy(obj)
-                continue
 
-            if not handled_by_standard(obj):
-                return
+                if not handled_by_standard(obj):
+                    return
 
-        # The last dmarker may belong to the next version (if dmarker["Key"] != obj["Key"] ), keep it
-        previous_deletemarkers.append(dmarker)
-        # And all following may too, if any, so add them now.
-        while deletemarkers:
-            previous_deletemarkers.append(deletemarkers.pop(0))
+            # Handle object delete marker.
+            else:
+                # Restore delete marker if the latest object is a version.
+                if obj_latest["IsVersion"]:
+                    handled_by_delete(obj)
+
+            # Remove the processed key from the running aggregate.
+            # FIXME this doesn't work as long as there are early continues and returns above!
+            del aggr_objects_by_key[key]
+
 
         for future in concurrent.futures.as_completed(futures):
             if future in futures:
@@ -454,26 +465,6 @@ def do_restore():
                     print_obj(futures[future])
                 except Exception as ex:
                     print('"%s" %s %s %s %s "ERROR: %s"' % (obj["LastModified"], obj["VersionId"], obj["Size"], obj["StorageClass"], obj["Key"], ex), file=sys.stderr)
-                del(futures[future])
-
-    # Process leftover delete markers.
-    while previous_deletemarkers:
-        dmarker = previous_deletemarkers.pop(0)
-        if dmarker['IsLatest']:
-            # The given object is already deleted and does not have to be deleted again.
-            obj_needs_be_deleted.pop(dmarker["Key"], None)
-
-    # delete objects which came in existence after pit_end_date only if the destination bucket is same as source bucket and restoring to same object key
-    if args.dest_bucket == args.bucket and not args.dest_prefix:
-        for key in obj_needs_be_deleted:
-            handled_by_delete(obj_needs_be_deleted[key])
-        for future in concurrent.futures.as_completed(futures):
-            if future in futures:
-                try:
-                    future.result()
-                    print_obj(futures[future])
-                except Exception as ex:
-                    print('"%s" %s %s %s %s "ERROR: %s"' % (obj["LastModified"], obj["VersionId"], obj["Size"], obj["StorageClass"], obj["Key"], ex))
                 del(futures[future])
 
 if __name__=='__main__':


### PR DESCRIPTION
Responses from the S3 ListObjectVersions API may have pages where the Versions list is not present because the DeleteMarkers list takes up the entire page.

Fix that bug and rework the strategy to make it clearer and easier to reason about.